### PR TITLE
feat: Add PHP 8.1+ and Bun to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Packages:
 
 ## Requirements
 
-- PHP
+- PHP 8.1+
+- Bun
 - Composer
 
 ## Install


### PR DESCRIPTION
Adds PHP 8.1+ and Bun to the list of requirements in the README.
This ensures that the project is compatible with the latest version
of PHP and includes support for the Bun runtime.